### PR TITLE
fix: resolve null reference in mobile layout adjustment

### DIFF
--- a/script.js
+++ b/script.js
@@ -278,16 +278,15 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
 
-    // Function for mobile adjustments (unchanged)
+    // Function for mobile adjustments
     function adjustIndexPageForMobile() {
         const container = document.querySelector('.container');
-        const auctionTimeHeight = document.querySelector('.auction-time').offsetHeight;
-        const buttonsHeight = document.querySelector('.connect-wallet-btn').offsetHeight + 
-                              document.querySelector('.gallery-btn').offsetHeight;
+        const headerBar = document.querySelector('.header-bar');
+        const buttonContainer = document.querySelector('.button-container');
         const padding = parseInt(getComputedStyle(container).paddingTop, 10) * 2;
         
         // Calculate available height for the table
-        const availableTableHeight = window.innerHeight - auctionTimeHeight - buttonsHeight - padding;
+        const availableTableHeight = window.innerHeight - headerBar.offsetHeight - buttonContainer.offsetHeight - padding;
         
         // Adjust table max-height
         document.getElementById('bidsTable').style.maxHeight = `${availableTableHeight}px`;


### PR DESCRIPTION
Fix Mobile Layout TypeError on Index Page

## Description
This PR fixes a TypeError that occurs when loading `index.html` due to attempting to access `.offsetHeight` of a non-existent `.auction-time` element. The error specifically occurs in the `adjustIndexPageForMobile` function which handles mobile responsive layout adjustments.

```javascript
TypeError: Cannot read properties of null (reading 'offsetHeight')
    at adjustIndexPageForMobile (script.js:284:74)
```

## Changes
- Refactored mobile layout adjustment logic to use existing container elements
- Replaced individual element height calculations with more reliable container-based measurements
- Removed dependency on non-existent `.auction-time` class
- Maintained all existing mobile responsiveness functionality

## Testing
To test this change:
1. Load index.html on mobile and desktop viewports
2. Verify table height adjusts correctly on both screen sizes
3. Verify font size adjustments still work on mobile (width <= 600px)
4. Check browser console for absence of TypeError

## Screenshots
<!-- Please add before/after screenshots if applicable -->

## Additional Notes
This fix improves the reliability of the mobile layout calculations by using the `.header-bar` container instead of trying to access individual elements that may not exist in the DOM.

## Author
@schoad

## Date
2025-01-18 01:35:38 UTC