### PR TITLE
Enhance ENS Caching and Optimize Bid Data Retrieval

### DIFF
--- a/caching.js
+++ b/caching.js
@@ -1,9 +1,9 @@
 // caching.js
 export const Cache = {
-    // ENS cache with 1-hour TTL
+    // ENS cache with 30-day TTL (approximately 2592000000 milliseconds)
     ens: {
         data: new Map(),
-        ttl: 3600000, // 1 hour in milliseconds
+        ttl: 2592000000, // 30 days in milliseconds
         get: function(address) {
             const cached = this.data.get(address);
             if (cached && Date.now() - cached.timestamp < this.ttl) {
@@ -16,31 +16,14 @@ export const Cache = {
                 value: name,
                 timestamp: Date.now()
             });
-        }
-    },
-
-    // Bids cache with 30-second TTL
-    bids: {
-        data: new Map(),
-        ttl: 30000, // 30 seconds in milliseconds
-        get: function(weekIndex) {
-            const cached = this.data.get(weekIndex);
-            if (cached && Date.now() - cached.timestamp < this.ttl) {
-                return cached.value;
-            }
-            return null;
         },
-        set: function(weekIndex, bids) {
-            this.data.set(weekIndex, {
-                value: bids,
-                timestamp: Date.now()
-            });
+        invalidate: function(address) {
+            this.data.delete(address);
         }
     },
 
     // Clear all caches
     clear: function() {
         this.ens.data.clear();
-        this.bids.data.clear();
     }
 };

--- a/script.js
+++ b/script.js
@@ -29,7 +29,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (!response.ok) {
                 throw new Error('No data for this week');
             }
-    
+
             const data = await response.json();
             console.log(`Fetched data for week ${selectedWeek}:`, data);
 
@@ -49,8 +49,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     rawAddress: data.bids.users[index].address
                 }));
             }
-    
-            Cache.bids.set(weekIndex, processedBids);
+
             await updateBidsTable(processedBids);
             noAuctionMessage.classList.add('hidden'); // Hide no auction message if data was fetched successfully
         } catch (error) {
@@ -141,12 +140,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (!response.ok) {
                 throw new Error('No data for this week');
             }
-    
+
             const data = await response.json();
             if (!data.auction || !data.auction.endTime) {
                 throw new Error('Auction time data not available');
             }
-    
+
             const endTime = data.auction.endTime * 1000; // Convert Unix timestamp to milliseconds
             
             const updateAuctionTime = () => {
@@ -163,14 +162,14 @@ document.addEventListener('DOMContentLoaded', async () => {
                     clearInterval(auctionInterval);
                 }
             };
-    
+
             if (auctionInterval) {
                 clearInterval(auctionInterval);
             }
-    
+
             updateAuctionTime();
             auctionInterval = setInterval(updateAuctionTime, 1000);
-    
+
         } catch (error) {
             console.error("Error fetching auction time from JSON:", error);
             document.getElementById('timeRemaining').innerText = "No Auction";
@@ -180,7 +179,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Event listener for week selection
     weekSelectIndex.addEventListener('change', async () => {
         selectedWeek = parseInt(weekSelectIndex.value, 10);
-        Cache.bids.data.delete(selectedWeek - 1); // Clear cache for new week
         await fetchBids();
         await fetchAuctionTime();
         if (isWalletConnected) {


### PR DESCRIPTION
### Summary

This pull request enhances the ENS caching mechanism by extending the TTL to 30 days and adds a method to invalidate specific cache entries. It also removes the bid data caching to ensure fresh data retrieval directly from the GitHub repository, updated every 30 seconds.

### Changes

1. **Extended ENS Cache TTL:**
   - The TTL for ENS cache has been extended to 30 days to reduce the frequency of lookups and improve performance.

2. **Cache Invalidation:**
   - Added a method to invalidate the ENS cache for specific addresses, allowing for manual cache management if needed.

3. **Removed Bid Data Caching:**
   - Bid data is now fetched directly from the GitHub repository without caching to ensure the data is always up-to-date.

4. **Updated ENS Resolution:**
   - Ensured the `resolveENS` function uses the updated cache implementation.

### Testing

1. **ENS Caching:**
   - Confirm that ENS names are cached and reused for subsequent lookups within the extended TTL period.
   - Test the cache invalidation method by manually invalidating specific cache entries and checking if the ENS name is re-looked up.

2. **Bid Data Retrieval:**
   - Verify that bid data is fetched directly from the GitHub repository and displayed correctly without caching.

3. **Performance:**
   - Monitor the performance of ENS lookups and bid data retrieval to ensure there are no noticeable delays.

Please review the changes and provide feedback or approval.