### PR TITLE
Fix Week Selector Button on Mobile Devices in Gallery

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NFT Gallery</title>
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="gallery.css">


### PR DESCRIPTION
This pull request addresses an issue with the week selector button on the gallery.html page not working on mobile devices. The issue was not present on the index.html page.

### Changes

1. **Viewport Meta Tag:**
   - Updated the viewport meta tag in gallery.html to match the one in index.html for consistency.

### Testing

1. **Week Selector Button:**
   - Verify that the week selector button works correctly on both mobile and desktop devices.
   - Ensure that the functionality is consistent with the index.html page.

Please review the changes and provide feedback or approval.all devices.