### PR TITLE
Hotfix: Prevent Caching for All Requests to cosmos-auctions-data

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,11 +21,37 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Global variable to keep track of the last update time
     window.lastUpdateTime = new Date(0); // Initialize to a very old date
 
+    // Function to fetch and check for data updates
+    async function checkForUpdates() {
+        try {
+            const url = `https://raw.githubusercontent.com/schoad/cosmos-auctions-data/main/data/index.json?timestamp=${new Date().getTime()}`;
+            const response = await fetch(url);
+            if (!response.ok) {
+                throw new Error('Error fetching index.json');
+            }
+
+            const indexData = await response.json();
+            const lastUpdated = new Date(indexData.lastUpdated);
+
+            // Check if data has been updated
+            if (lastUpdated > window.lastUpdateTime) {
+                window.lastUpdateTime = lastUpdated;
+                await fetchBids();  // Refresh the bids data
+                await fetchAuctionTime();  // Refresh the auction time
+            }
+        } catch (error) {
+            console.error('Error checking for updates:', error);
+        }
+    }
+
+    // Set an interval to check for updates every 15 seconds
+    setInterval(checkForUpdates, 15000);
+
     // Fetch bids from GitHub
     async function fetchBids() {
         try {
             const weekIndex = selectedWeek - 1;
-            const url = `https://raw.githubusercontent.com/schoad/cosmos-auctions-data/main/data/week_${weekIndex}.json`;
+            const url = `https://raw.githubusercontent.com/schoad/cosmos-auctions-data/main/data/week_${weekIndex}.json?timestamp=${new Date().getTime()}`;
             console.log(`Fetching data from: ${url}`);
             const response = await fetch(url);
             
@@ -138,7 +164,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     const fetchAuctionTime = async () => {
         try {
             const weekIndex = selectedWeek - 1;
-            const response = await fetch(`https://raw.githubusercontent.com/schoad/cosmos-auctions-data/main/data/week_${weekIndex}.json`);
+            const url = `https://raw.githubusercontent.com/schoad/cosmos-auctions-data/main/data/week_${weekIndex}.json?timestamp=${new Date().getTime()}`;
+            const response = await fetch(url);
             
             if (!response.ok) {
                 throw new Error('No data for this week');
@@ -178,32 +205,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             document.getElementById('timeRemaining').innerText = "No Auction";
         }
     };
-
-    // Function to fetch and check for data updates
-    async function checkForUpdates() {
-        try {
-            const url = `https://raw.githubusercontent.com/schoad/cosmos-auctions-data/main/data/index.json?timestamp=${new Date().getTime()}`;
-            const response = await fetch(url);
-            if (!response.ok) {
-                throw new Error('Error fetching index.json');
-            }
-
-            const indexData = await response.json();
-            const lastUpdated = new Date(indexData.lastUpdated);
-
-            // Check if data has been updated
-            if (lastUpdated > window.lastUpdateTime) {
-                window.lastUpdateTime = lastUpdated;
-                await fetchBids();  // Refresh the bids data
-                await fetchAuctionTime();  // Refresh the auction time
-            }
-        } catch (error) {
-            console.error('Error checking for updates:', error);
-        }
-    }
-
-    // Set an interval to check for updates every 15 seconds
-    setInterval(checkForUpdates, 15000);
 
     // Event listener for week selection
     weekSelectIndex.addEventListener('change', async () => {

--- a/script.js
+++ b/script.js
@@ -182,7 +182,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Function to fetch and check for data updates
     async function checkForUpdates() {
         try {
-            const response = await fetch('https://raw.githubusercontent.com/schoad/cosmos-auctions-data/main/data/index.json');
+            const url = `https://raw.githubusercontent.com/schoad/cosmos-auctions-data/main/data/index.json?timestamp=${new Date().getTime()}`;
+            const response = await fetch(url);
             if (!response.ok) {
                 throw new Error('Error fetching index.json');
             }


### PR DESCRIPTION
### Description
This hotfix ensures that all requests to the `schoad/cosmos-auctions-data` GitHub repository are not served from the disk cache, allowing for real-time data updates. A cache-busting query parameter with the current timestamp is added to all relevant URLs to ensure the browser fetches the latest version from the server.

### Changes Made
- Added a cache-busting query parameter to all requests to the `schoad/cosmos-auctions-data` repository in the `fetchBids`, `fetchAuctionTime`, and `checkForUpdates` functions.
- Ensured that the `index.json` and weekly data files are fetched with the latest data to reflect real-time updates.

### Testing
- Verified that all requests to the `schoad/cosmos-auctions-data` repository are fetched with the latest data.
- Ensured that the existing functionality for fetching bids and auction time remains intact.

### Notes
This update is essential to provide real-time updates for users and improve the overall user experience. Please review and merge this hotfix at the earliest convenience.